### PR TITLE
Actually display the "open in new window" icon.

### DIFF
--- a/doxia-site-renderer/src/main/resources/org/apache/maven/doxia/siterenderer/resources/default-site.vm
+++ b/doxia-site-renderer/src/main/resources/org/apache/maven/doxia/siterenderer/resources/default-site.vm
@@ -30,6 +30,8 @@ under the License.
     $href.toLowerCase().startsWith("ftp:/") || $href.toLowerCase().startsWith("mailto:") ||
     $href.toLowerCase().startsWith("file:/") || ($href.toLowerCase().indexOf("://") != -1) )
     #set ( $linkClass = ' class="externalLink"' )
+  #elseif( $target && $target == "_blank" )
+    #set ( $linkClass = ' class="newWindow"' )
   #else
     #set ( $linkClass = "" )
   #end


### PR DESCRIPTION
I understand this is the default `site.vm` used by `(org.apache.maven.plugins/)maven-site-plugin`.
I understand default skins package `(org.apache.maven.skins/maven-skins)` including the default skin `(org.apache.maven.skins/)maven-default-skin` do provide CSS with class for links (html `<a>` tag) with "newWindow" in turn leveraging the newwindow.png made available by the skin.
Similarly to what happens for "externalLink" for external.png which is demonstrated by the already existing original code, just the line above my proposed code change.

This proposed code change do actually leverage the "newWindow" (html a) CSS class in turn leveraging the newwindow.png made available by the maven default skins.

Please notice the priority is given to the "external link" icon. If the link is NOT an external link, but it is to be opened in a new window because target is "_blank", then the relevant CSS class is applied.

Thank you.