### PR TITLE
Update commons-collections

### DIFF
--- a/doxia-site-renderer/pom.xml
+++ b/doxia-site-renderer/pom.xml
@@ -132,7 +132,7 @@ under the License.
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
In order to mute warnings for CVE-2015-6420 and CVE-2017-15708 in 3rd party projects. Likely a false positive, just making sure.