### PR TITLE
revert very old plexus to even older one

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -95,6 +95,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-container-default</artifactId>
+      <version>1.0-alpha-9</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
@michael-o @rfscholte This seems to make Jenkins happy, though it causes me a weird failure locally. I filed https://issues.apache.org/jira/browse/DOXIASITETOOLS-224 to try to get these dependencies to be less than ten years old. 

