### PR TITLE
[DOXIA-611] Add line number to RendererException message only when available

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -441,8 +441,14 @@ public class DefaultSiteRenderer
         }
         catch ( ParseException e )
         {
-            throw new RendererException( "Error parsing '"
-                    + doc + "': line [" + e.getLineNumber() + "] " + e.getMessage(), e );
+            StringBuilder errorMsgBuilder = new StringBuilder();
+            errorMsgBuilder.append( "Error parsing '" ).append( doc ).append( "': " );
+            if ( e.getLineNumber() > 0 )
+            {
+                errorMsgBuilder.append( "line [" ).append( e.getLineNumber() ).append( "] " );
+            }
+            errorMsgBuilder.append( e.getMessage() );
+            throw new RendererException( errorMsgBuilder.toString(), e );
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
Related issue: https://issues.apache.org/jira/browse/DOXIA-611

This PR fixes the issue adding some treatment of the error message in case line number values is not valid.
I have considered as valid values extrict positives.