### PR TITLE
[DOXIA-614] Pass input file name as reference to parser

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -432,7 +432,7 @@ public class DefaultSiteRenderer
             }
             sink.enableLogging( new PlexusLoggerWrapper( getLogger() ) );
 
-            doxia.parse( reader, docRenderingContext.getParserId(), sink );
+            doxia.parse( reader, docRenderingContext.getParserId(), sink , docRenderingContext.getInputName() );
         }
         catch ( ParserNotFoundException e )
         {

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
@@ -166,7 +166,7 @@ public class DefaultSiteRendererTest
         Doxia doxiaSpy = spy( doxiaInstance );
         Mockito.doThrow( new ParseException( exceptionMessage ) )
                 .when( doxiaSpy )
-                .parse( Mockito.<Reader>any(), Mockito.anyString(), Mockito.<Sink>any() );
+                .parse( Mockito.<Reader>any(), Mockito.anyString(), Mockito.<Sink>any(), Mockito.anyString() );
         Renderer renderer = (Renderer) lookup( Renderer.class );
         ReflectionUtils.setVariableValueInObject( renderer, "doxia", doxiaSpy );
 
@@ -201,7 +201,7 @@ public class DefaultSiteRendererTest
         Doxia doxiaSpy = spy( doxiaInstance );
         Mockito.doThrow( new ParseException( exceptionMessage, 42, 36 ) )
                 .when( doxiaSpy )
-                .parse( Mockito.<Reader>any(), Mockito.anyString(), Mockito.<Sink>any() );
+                .parse( Mockito.<Reader>any(), Mockito.anyString(), Mockito.<Sink>any(), Mockito.anyString() );
         Renderer renderer = (Renderer) lookup( Renderer.class );
         ReflectionUtils.setVariableValueInObject( renderer, "doxia", doxiaSpy );
 


### PR DESCRIPTION
Second part of https://issues.apache.org/jira/browse/DOXIA-614 (first: https://github.com/apache/maven-doxia/pull/35).
The first change allowed DoxiaParsers to receive the "reference" to the source alongside the Reader, but we still need to pass the value fo the reference, otherwise it's alwasy null.

I decided on just pass the relative reference instead of absolute path for security reasons (ie. expose internal paths).