### PR TITLE
[DOXIASITETOOLS-268] - Improve performance by only loading the renderer version once during class initialization

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -150,6 +150,36 @@ public class DefaultSiteRenderer
     private static final String SKIN_TEMPLATE_LOCATION = "META-INF/maven/site.vm";
 
     private static final String TOOLS_LOCATION = "META-INF/maven/site-tools.xml";
+    
+    private static final String DOXIA_SITE_RENDERER_VERSION;
+    
+    static
+    {
+        InputStream inputStream = DefaultSiteRenderer.class.getResourceAsStream( "/META-INF/"
+                + "maven/org.apache.maven.doxia/doxia-site-renderer/pom.properties" );
+        
+        String version = null;
+        if ( inputStream == null )
+        {
+            LOGGER.debug( "pom.properties for doxia-site-renderer could not be found." );
+        }
+        else
+        {
+            Properties properties = new Properties();
+            try ( InputStream in = inputStream )
+            {
+                properties.load( in );
+                version = properties.getProperty( "version" );
+            }
+            catch ( IOException e )
+            {
+                LOGGER.debug( "Failed to load pom.properties, so doxiaSiteRendererVersion is not available"
+                        + " in the Velocity context." );
+            }
+        }
+        
+        DOXIA_SITE_RENDERER_VERSION = version;
+    }
 
     // ----------------------------------------------------------------------
     // Renderer implementation
@@ -556,26 +586,7 @@ public class DefaultSiteRenderer
         context.put( "publishDate", siteRenderingContext.getPublishDate() );
 
         // doxiaSiteRendererVersion
-        InputStream inputStream = this.getClass().getResourceAsStream( "/META-INF/"
-            + "maven/org.apache.maven.doxia/doxia-site-renderer/pom.properties" );
-        if ( inputStream == null )
-        {
-            LOGGER.debug( "pom.properties for doxia-site-renderer could not be found." );
-        }
-        else
-        {
-            Properties properties = new Properties();
-            try ( InputStream in = inputStream )
-            {
-                properties.load( in );
-                context.put( "doxiaSiteRendererVersion", properties.getProperty( "version" ) );
-            }
-            catch ( IOException e )
-            {
-                LOGGER.debug( "Failed to load pom.properties, so doxiaSiteRendererVersion is not available"
-                        + " in the Velocity context." );
-            }
-        }
+        context.put( "doxiaSiteRendererVersion", DOXIA_SITE_RENDERER_VERSION );
 
         // Add user properties
         Map<String, ?> templateProperties = siteRenderingContext.getTemplateProperties();


### PR DESCRIPTION
Loading the version information on every file render significantly slows down the Doxia rendering phase. I observed at least a 10x speedup on 45k Markdown files by moving this resource loading to a static initialization block.