### PR TITLE
[DOXIASITETOOLS-344] - Improve performance of case-sensitive file key checking

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -208,6 +209,8 @@ public class DefaultSiteRenderer implements Renderer {
 
         List<String> allFiles = FileUtils.getFileNames(moduleBasedir, "**/*", excludes, false);
 
+        Map<String, String> caseInsensitiveFiles = new HashMap<>();
+
         for (String extension : module.getExtensions()) {
             String fullExtension = "." + extension;
 
@@ -243,23 +246,22 @@ public class DefaultSiteRenderer implements Renderer {
                 // -----------------------------------------------------------------------
                 // Handle key without case differences
                 // -----------------------------------------------------------------------
-                for (Map.Entry<String, DocumentRenderer> entry : files.entrySet()) {
-                    if (entry.getKey().equalsIgnoreCase(key)) {
-                        DocumentRenderingContext originalDocRenderingContext =
-                                entry.getValue().getRenderingContext();
+                String originalKey = caseInsensitiveFiles.put(key.toLowerCase(Locale.ROOT), key);
+                if (originalKey != null) {
+                    DocumentRenderingContext originalDocRenderingContext =
+                            files.get(originalKey).getRenderingContext();
 
-                        File originalDoc = new File(
-                                originalDocRenderingContext.getBasedir(), originalDocRenderingContext.getInputName());
+                    File originalDoc = new File(
+                            originalDocRenderingContext.getBasedir(), originalDocRenderingContext.getInputName());
 
-                        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                            throw new RendererException("File '" + module.getSourceDirectory() + File.separator + doc
-                                    + "' clashes with existing '" + originalDoc + "'.");
-                        }
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        throw new RendererException("File '" + module.getSourceDirectory() + File.separator + doc
+                                + "' clashes with existing '" + originalDoc + "'.");
+                    }
 
-                        if (LOGGER.isWarnEnabled()) {
-                            LOGGER.warn("File '" + module.getSourceDirectory() + File.separator + doc
-                                    + "' could clash with existing '" + originalDoc + "'.");
-                        }
+                    if (LOGGER.isWarnEnabled()) {
+                        LOGGER.warn("File '" + module.getSourceDirectory() + File.separator + doc
+                                + "' could clash with existing '" + originalDoc + "'.");
                     }
                 }
 


### PR DESCRIPTION
Our Maven site now has about 150,000 Doxia files to render (mostly Markdown and some ASCII doc). During profiling, I realized the Maven site plugin was spending around 18 minutes in the addModuleFiles() method. When looking at the code, I realized the algorithm was O(n² - n / 2) the way it adds each file it discovers to a map and the iterates through the map for each file.

This approach uses a secondary hash map to achieve O(2n) instead to check for a case-insensitive duplicate file to error on Windows and warn on other OSes.

(second attempt starting with the latest `master` branch and adding the ticket to the commit)