### PR TITLE
[DOXIASITETOOLS-359] Support site directories where duplicates are

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
@@ -43,10 +43,23 @@ public class SiteRenderingContext {
     public static class SiteDirectory {
         private File path;
         private boolean editable;
+        private boolean skipDuplicates;
 
         public SiteDirectory(File path, boolean editable) {
+            this(path, editable, false);
+        }
+
+        /**
+         *
+         * @param path
+         * @param editable
+         * @param skipDuplicates flag indicating if duplicates in this directory should be skipped ({@code true}) or lead to an exception ({@code false})
+         * @since 2.1
+         */
+        public SiteDirectory(File path, boolean editable, boolean skipDuplicates) {
             this.path = path;
             this.editable = editable;
+            this.skipDuplicates = skipDuplicates;
         }
 
         public File getPath() {
@@ -55,6 +68,10 @@ public class SiteRenderingContext {
 
         public boolean isEditable() {
             return editable;
+        }
+
+        public boolean isSkipDuplicates() {
+            return skipDuplicates;
         }
     }
 


### PR DESCRIPTION
skipped

Usually a duplicate relative file path in multiple site directories lead to a RendererException (because only one can end up in the built site). For some cases it is beneficial to add source directories where duplicates should be just silently skipped (for example to allow overwriting certain files in previous sources).