### PR TITLE
DOXIASITETOOLS-356: Provide more context in error message

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -700,9 +700,10 @@ public class DefaultSiteRenderer implements Renderer {
                 if (StringUtils.isNotBlank(toolsPrerequisite)
                         && (current != null)
                         && !matchVersion(current, toolsPrerequisite)) {
-                    throw new RendererException("Cannot use skin as it needs " + toolsPrerequisite
-                            + " Doxia Sitetools, but your configuration uses " + current + "."
-                            + "Check your version setup of plugins and skins to use the same doxia stack.");
+                    throw new RendererException("Your current Doxia Sitetools version " + current
+                            + " does not match the requirements of the skin (" + toolsPrerequisite
+                            + "). In order to fix this choose a skin version that is "
+                            + "compatible with this Doxia Sitetools version.");
                 }
             }
         } catch (XmlPullParserException e) {

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -700,8 +700,9 @@ public class DefaultSiteRenderer implements Renderer {
                 if (StringUtils.isNotBlank(toolsPrerequisite)
                         && (current != null)
                         && !matchVersion(current, toolsPrerequisite)) {
-                    throw new RendererException("Cannot use skin: has " + toolsPrerequisite
-                            + " Doxia Sitetools prerequisite, but current is " + current);
+                    throw new RendererException("Cannot use skin as it needs " + toolsPrerequisite
+                            + " Doxia Sitetools, but your configuration uses " + current + "."
+                            + "Check your version setup of plugins and skins to use the same doxia stack.");
                 }
             }
         } catch (XmlPullParserException e) {


### PR DESCRIPTION
Provide more context when version mismatches arise during doxia migration

Inspired by discussion on https://github.com/apache/maven-doxia-sitetools/pull/184