### PR TITLE
Prevent IllegalStateException when using deprecated

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DocumentRenderingContext.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DocumentRenderingContext.java
@@ -59,7 +59,7 @@ public class DocumentRenderingContext {
      */
     private final Collection<File> sourceDirectories;
 
-    /** The project's build directory, may be {@code null} rendered from a Doxia source) */
+    /** The project's build directory, may be {@code null} if not rendered from a Doxia source */
     private final File rootDirectory;
 
     /** The site's root directory, must be below {@link #rootDirectory}, may be {@code null} if not rendered from a Doxia source */
@@ -106,7 +106,7 @@ public class DocumentRenderingContext {
     /**
      *
      * @param basedir
-     * @param basedirRelativePath
+     * @param basedirRelativePath (may be null if not a Doxia source)
      * @param document
      * @param parserId
      * @param extension
@@ -183,10 +183,11 @@ public class DocumentRenderingContext {
                 document,
                 parserId,
                 extension,
-                stripSuffixFromPath(basedir, basedirRelativePath),
+                // only generate root directory when basedirRelativePath is provided (for a doxia source)
+                basedirRelativePath == null ? null : stripSuffixFromPath(basedir, basedirRelativePath),
                 // assume that site root is the parent of basedir (i.e. module specific source directory is directly
-                // below site root)
-                basedir.getParentFile(),
+                // below site root), only when basedirRelativePath is provided (for a doxia source)
+                basedirRelativePath == null ? null : basedir.getParentFile(),
                 editable ? Collections.singleton(basedir) : Collections.emptySet(),
                 generator);
     }

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DocumentRenderingContextTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DocumentRenderingContextTest.java
@@ -113,4 +113,16 @@ class DocumentRenderingContextTest {
         assertEquals("path/file.html", docRenderingContext.getOutputPath());
         assertEquals("..", docRenderingContext.getRelativePath());
     }
+
+    @Test
+    void testConstructorWithNullBasedirRelativePath() {
+        File basedir = new File(".");
+        DocumentRenderingContext context =
+                new DocumentRenderingContext(basedir, null, "document", "markdown", null, false);
+        assertNull(context.getBasedirRelativePath());
+        assertNull(context.getDoxiaSourcePath());
+        context = new DocumentRenderingContext(basedir, null, "document", "markdown", null, false, "generator");
+        assertNull(context.getBasedirRelativePath());
+        assertNull(context.getDoxiaSourcePath());
+    }
 }


### PR DESCRIPTION
DocumentRenderingContext constructors with basedirRelativePath being null

In case basedirRelativePath is null neither rootDirectory nor siteRootDirectory should be set, as in that case also basedir is a pseudo directory.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
