### PR TITLE
Keep Markdown headings from being read as Velocity comments

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -146,6 +146,11 @@ public class DefaultSiteRenderer implements Renderer {
     @Inject
     private Map<String, ContextCustomizer> contextCustomizers;
 
+    /** Opens a block Velocity passes through without interpreting it. */
+    private static final String VELOCITY_UNPARSED_START = "#[[";
+
+    private static final String VELOCITY_UNPARSED_END = "]]#";
+
     private static final String SKIN_TEMPLATE_LOCATION = "META-INF/maven/site.vm";
 
     private static final String TOOLS_LOCATION = "META-INF/maven/site-tools.xml";
@@ -404,6 +409,59 @@ public class DefaultSiteRenderer implements Renderer {
         }
     }
 
+    /**
+     * A Markdown ATX heading below level one starts with {@code ##}, which is also how a Velocity
+     * line comment starts. In a {@code *.md.vm} document Velocity therefore strips the heading
+     * before Doxia ever sees it and the page silently loses the whole line.
+     *
+     * <p>Wrapping such a line in Velocity's unparsed block {@code #[[ ... ]]#} passes it through
+     * untouched. Only documents actually holding such a heading are rewritten, so a document that
+     * renders correctly today is handed to Velocity exactly as before.</p>
+     *
+     * @param doc the Velocity template about to be rendered
+     * @param docRenderingContext the context of the document
+     * @param encoding the encoding to read the template with
+     * @return the template with its hidden headings shielded, or {@code null} if it has none and
+     * should be rendered the usual way
+     */
+    private String shieldHeadingsHiddenFromMarkdown(
+            File doc, DocumentRenderingContext docRenderingContext, String encoding) {
+        if (!"markdown".equals(docRenderingContext.getParserId())) {
+            return null;
+        }
+        StringBuilder shielded = new StringBuilder();
+        int count = 0;
+        try (BufferedReader reader = new BufferedReader(ReaderFactory.newReader(doc, encoding))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // up to three leading spaces still make an ATX heading, four or more make indented code
+                int indent = 0;
+                while (indent < line.length() && indent < 4 && line.charAt(indent) == ' ') {
+                    indent++;
+                }
+                // every level below one starts with ##, so ### and deeper are hidden just the same
+                if (indent < 4 && line.startsWith("##", indent)) {
+                    shielded.append(VELOCITY_UNPARSED_START).append(line).append(VELOCITY_UNPARSED_END);
+                    count++;
+                } else {
+                    shielded.append(line);
+                }
+                shielded.append(System.lineSeparator());
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Could not read " + doc + " to shield its Markdown headings from Velocity", e);
+            return null;
+        }
+        if (count == 0) {
+            return null;
+        }
+        LOGGER.debug(
+                "Shielded {} Markdown heading(s) in {} which Velocity would otherwise have read as comments",
+                count,
+                docRenderingContext.getDoxiaSourcePath());
+        return shielded.toString();
+    }
+
     /** {@inheritDoc} */
     public void renderDocument(
             Writer writer, DocumentRenderingContext docRenderingContext, SiteRenderingContext siteContext)
@@ -438,7 +496,13 @@ public class DefaultSiteRenderer implements Renderer {
 
                     StringWriter sw = new StringWriter();
 
-                    velocity.getEngine().mergeTemplate(resource, siteContext.getInputEncoding(), vc, sw);
+                    String shielded =
+                            shieldHeadingsHiddenFromMarkdown(doc, docRenderingContext, siteContext.getInputEncoding());
+                    if (shielded != null) {
+                        velocity.getEngine().evaluate(vc, sw, resource, shielded);
+                    } else {
+                        velocity.getEngine().mergeTemplate(resource, siteContext.getInputEncoding(), vc, sw);
+                    }
 
                     String doxiaContent = sw.toString();
 

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
@@ -288,6 +288,40 @@ public class DefaultSiteRendererTest {
         siteRenderer.copyResources(context, outputDirectory);
     }
 
+    /**
+     * A Markdown ATX heading below level one starts with {@code ##}, which Velocity reads as a line
+     * comment. Without shielding, every such heading disappears from a {@code *.md.vm} page.
+     */
+    @Test
+    void markdownHeadingsSurviveVelocity() throws Exception {
+        SiteModel siteModel =
+                new SiteXpp3Reader().read(new FileInputStream(getTestFile("src/test/resources/site/site.xml")));
+        SiteRenderingContext context =
+                getSiteRenderingContext(siteModel, minimalSkinJar, "src/test/resources/site", false);
+
+        File outputDirectory = getTestFile(OUTPUT);
+        org.apache.commons.io.FileUtils.deleteDirectory(outputDirectory);
+        DocumentRenderingContext docRenderingContext = new DocumentRenderingContext(
+                getTestFile("src/test/resources/site/markdown"),
+                "src/test/resources/site/markdown",
+                "velocity-headings.md.vm",
+                "markdown",
+                "md",
+                false);
+        // this is what the directory scan does for a *.vm source, and what makes Velocity run
+        docRenderingContext.setAttribute("velocity", "true");
+        siteRenderer.render(
+                Collections.singletonList(new DoxiaDocumentRenderer(docRenderingContext)), context, outputDirectory);
+
+        String rendered = new String(
+                Files.readAllBytes(
+                        getTestFile("target/output/velocity-headings.html").toPath()),
+                StandardCharsets.UTF_8);
+        assertTrue(rendered.contains("<h1>Top Heading</h1>"), rendered);
+        assertTrue(rendered.contains("<h2>Second Level</h2>"), rendered);
+        assertTrue(rendered.contains("<h3>Third Level</h3>"), rendered);
+    }
+
     @Test
     void mermaidWithExternalJs() throws Exception {
         SiteModel siteModel = new SiteXpp3Reader()

--- a/doxia-site-renderer/src/test/resources/site/markdown/velocity-headings.md.vm
+++ b/doxia-site-renderer/src/test/resources/site/markdown/velocity-headings.md.vm
@@ -1,0 +1,31 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Top Heading
+
+Velocity reads a doubled hash at the start of a line as a comment, so the
+headings below would be dropped before Doxia ever sees this document.
+
+## Second Level
+
+Text under the second level heading.
+
+### Third Level
+
+Text under the third level heading.


### PR DESCRIPTION
A Markdown ATX heading below level one starts with ##, which is also how a
Velocity line comment starts. In a *.md.vm document Velocity strips the
heading before Doxia ever sees it, so the whole line disappears from the
rendered page with no error and no warning.

Pages in the wild hit this today, among them maven-release-plugin's usage
and migrate pages, maven-checkstyle-plugin's history page and
maven-scm-plugin's scm-advance-features page: every subsection heading they
declare is missing from the published site.

Such lines are now wrapped in Velocity's unparsed block #[[ ... ]]# before
evaluation. Only a document that actually contains one is rewritten, and
only when it is parsed as Markdown, so every document rendering correctly
today still goes through mergeTemplate unchanged.

A doubled hash further along a line is left alone: there it really is a
Velocity comment, and Markdown gives it no meaning.


Part of the wider migration tracked in
https://github.com/apache/maven-doxia-converter/issues/139
