### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/doxia-integration-tools/src/site/markdown/index.md
+++ b/doxia-integration-tools/src/site/markdown/index.md
@@ -40,13 +40,13 @@ Interpolation of [`site.xml` model](../doxia-site-model/site.html) injects Maven
 Interpolation can be **late** or **early**:
 
 - with **late** interpolation, replacement happens **after** inheritance. This is the classical behaviour in Maven pom,
-- with **early** interpolation, replacement happens **before** inheritance: this was the default behaviour for `project.*` values until Doxia Sitetools 1\.7 \(used in [ Maven Site Plugin 3\.5](/plugins/maven-site-plugin/history.html)\), when these early and late interpolation definitions didn&apos;t exist. Since Doxia Sitetools 1\.7\.1 \(used in [ Maven Site Plugin 3\.5\.1](/plugins/maven-site-plugin/history.html)\), early interpolation happens for `this.*` values. Early interpolation doesn&apos;t support user and system properties.
+- with **early** interpolation, replacement happens **before** inheritance: this was the default behaviour for `project.*` values until Doxia Sitetools 1\.7 (used in [ Maven Site Plugin 3\.5](/plugins/maven-site-plugin/history.html)), when these early and late interpolation definitions didn&apos;t exist. Since Doxia Sitetools 1\.7\.1 (used in [ Maven Site Plugin 3\.5\.1](/plugins/maven-site-plugin/history.html)), early interpolation happens for `this.*` values. Early interpolation doesn&apos;t support user and system properties.
 
 Values are evaluated in sequence from different syntaxes:
 
 |late value|early value|evaluation result|common examples|
 |:---|:---|:---|:---|
-|`project.*`|`this.*`|POM content \(see [POM reference](/ref/current/maven-model/maven.html)\)|`${project.version}` <br />`${this.url}`|
+|`project.*`|`this.*`|POM content (see [POM reference](/ref/current/maven-model/maven.html))|`${project.version}` <br />`${this.url}`|
 |`*`|`this.*`|model properties, such as project properties set in the pom|`${any.key}` <br />`${this.any.key}`|
 |`env.*` <br />`*`||environment variables|`${env.PATH}`|
 

--- a/doxia-site-model/src/site/markdown/index.md
+++ b/doxia-site-model/src/site/markdown/index.md
@@ -34,7 +34,7 @@ The following are generated from this model:
 
 ## Inheritance
 
-Site model can be merged from a parent `site.xml` into a child `site.xml` using `SiteModelInheritanceAssembler` \([javadoc](./apidocs/org/apache/maven/doxia/site/inheritance/SiteModelInheritanceAssembler.html)\) with its `DefaultSiteModelInheritanceAssembler` implementation \([source](./xref/org/apache/maven/doxia/site/inheritance/DefaultSiteModelInheritanceAssembler.html)\).
+Site model can be merged from a parent `site.xml` into a child `site.xml` using `SiteModelInheritanceAssembler` ([javadoc](./apidocs/org/apache/maven/doxia/site/inheritance/SiteModelInheritanceAssembler.html)) with its `DefaultSiteModelInheritanceAssembler` implementation ([source](./xref/org/apache/maven/doxia/site/inheritance/DefaultSiteModelInheritanceAssembler.html)).
 
 ## Interpolation
 

--- a/doxia-site-renderer/src/site/markdown/index.md.vm
+++ b/doxia-site-renderer/src/site/markdown/index.md.vm
@@ -25,7 +25,7 @@ date: 2015-12-20
 
 # Doxia Sitetools - Site Renderer
 
-The Site Renderer handles the rendering of sites, assembling a common site template \(also called _a skin_\) with a collection of documents.
+The Site Renderer handles the rendering of sites, assembling a common site template (also called _a skin_) with a collection of documents.
 
 Documents can be dynamically generated with [Doxia Sink API](/doxia/doxia/doxia-sink-api/), like Maven reports, or simply read from static files written in [markup supported by Doxia Parsers](/doxia/references/index.html), optionally preprocessed by [Velocity](https://velocity.apache.org/engine/${velocityEngineVersion}) if their file names end with `.vm`.
 
@@ -33,7 +33,7 @@ Documents can be dynamically generated with [Doxia Sink API](/doxia/doxia/doxia-
 
 ${esc.h}${esc.h} Doxia Site Skins
 
-A default site template is included \(see `default-site.vm`\), but other templates can be used at will, either as a standalone template or packaged in a [**skin** artifact](../doxia-skin-model/).
+A default site template is included (see `default-site.vm`), but other templates can be used at will, either as a standalone template or packaged in a [**skin** artifact](../doxia-skin-model/).
 
 Maven team provides [a collection of skins](/skins/) for projects use.
 
@@ -48,10 +48,10 @@ The Velocity context contains some variables related to rendering context that y
 |Variable|Type|Description|
 |:---|:---|:---|
 |`alignedFileName`|`String`|**Deprecated**: use `alignedFilePath`.|
-|`alignedFilePath`|`String`|The file path of the \(HTML\) document being rendered, relative to the document being rendered.|
+|`alignedFilePath`|`String`|The file path of the (HTML) document being rendered, relative to the document being rendered.|
 |`decoration`|[`SiteModel`](../doxia-site-model/apidocs/org/apache/maven/doxia/site/SiteModel.html)|**Deprecated**: use `site`.|
 |`currentFileName`|`String`|**Deprecated**: use `currentFilePath`.|
-|`currentFilePath`|`String`|The file path of the \(HTML\) document being rendered, relative to the site root.|
+|`currentFilePath`|`String`|The file path of the (HTML) document being rendered, relative to the site root.|
 |`doxiaSiteRendererVersion`|`String`|The version of the Doxia Site Renderer in use.|
 |`locale`|`Locale`|The locale for the document being rendered.|
 |`publishDate`|`Date`|An optional hardcoded publish date that has been set programmatically.|
@@ -77,21 +77,21 @@ Additionally, there are [Velocity Generic Tools](https://velocity.apache.org/too
 
 |Variable|Type|Description|
 |:---|:---|:---|
-|`alternator`|[AlternatorTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use CSS3 nth-child\(even/odd\) selectors or ${esc.hash}if\($foreach.index % 2\). For creating alternators to easily alternate over a set of values.|
+|`alternator`|[AlternatorTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use CSS3 nth-child(even/odd) selectors or ${esc.hash}if($foreach.index % 2). For creating alternators to easily alternate over a set of values.|
 |`class`|[ClassTool]($generic${esc.hash}ClassTool)|For simplifying reflective lookup of information about classes and their fields, methods and constructors.|
 |`context`|[ContextTool]($generic${esc.hash}ContextTool)|For convenient access to context data and metadata.|
-|`convert`|[ConversionTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use NumberTool for numbers formatting/parsing, DateTool for date/time formatting/parsing, or CollectionTool for toStrings\(\). For converting String values to richer object Types.|
+|`convert`|[ConversionTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use NumberTool for numbers formatting/parsing, DateTool for date/time formatting/parsing, or CollectionTool for toStrings(). For converting String values to richer object Types.|
 |`date`|[ComparisonDateTool]($generic${esc.hash}ComparisonDateTool)|For manipulating, formatting, and comparing dates. The formatting pattern and timezone are taken from the site descriptors element &quot;publishDate&quot; &quot;format and &quot;timezone&quot; attributes, respectively.|
-|`display`|[DisplayTool]($generic${esc.hash}DisplayTool)|For controlling display of references \(e.g., truncating values, &quot;pretty printing&quot; lists, and displaying alternates when a reference is null\).|
-|`esc`|[EscapeTool]($generic${esc.hash}EscapeTool)|For common escaping needs in Velocity templates \(e.g. escaping html, xml, javascript etc.\).|
-|`field`|[FieldTool]($generic${esc.hash}FieldTool)|For \(easy\) access to static fields in a class, such as string constants.|
+|`display`|[DisplayTool]($generic${esc.hash}DisplayTool)|For controlling display of references (e.g., truncating values, &quot;pretty printing&quot; lists, and displaying alternates when a reference is null).|
+|`esc`|[EscapeTool]($generic${esc.hash}EscapeTool)|For common escaping needs in Velocity templates (e.g. escaping html, xml, javascript etc.).|
+|`field`|[FieldTool]($generic${esc.hash}FieldTool)|For (easy) access to static fields in a class, such as string constants.|
 |`link`|[LinkTool]($generic${esc.hash}LinkTool)|For creating and manipulating URIs and URLs. The API for this tool is designed to closely resemble that of the VelocityView tool of the same name.|
 |`loop`|[LoopTool]($generic${esc.hash}LoopTool)|A convenience tool to use with `${esc.hash}foreach` loops. It wraps a list with a custom iterator to provide greater control, allowing loops to end early, skip ahead and more.|
 |`math`|[MathTool]($generic${esc.hash}MathTool)|For performing math functions.|
 |`number`|[NumberTool]($generic${esc.hash}NumberTool)|For formatting and converting numbers.|
 |`render`|[RenderTool]($generic${esc.hash}RenderTool)|To evaluate and render arbitrary strings of VTL, including recursive rendering.|
 |`text`|[ResourceTool]($generic${esc.hash}ResourceTool)|For simplified access to resource bundles for internationalization or other dynamic content needs.|
-|`sorter`|[SortTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use CollectionTool sort methods. Used to sort collections \(or arrays, iterators, etc\) on any arbitary set of properties exposed by the objects contained within the collection.|
+|`sorter`|[SortTool]($generic${esc.hash}deprecated-tools)|[**Deprecated**]($generic${esc.hash}deprecated-tools): use CollectionTool sort methods. Used to sort collections (or arrays, iterators, etc) on any arbitary set of properties exposed by the objects contained within the collection.|
 |`xml`|[XmlTool]($generic${esc.hash}XmlTool)|For reading/navigating XML files. This uses dom4j under the covers and provides complete XPath support.|
 
 If you intend to use custom Velocity tools, add them to the Maven Site Plugin&apos;s dependency list and make sure that they have a bundled configuration file in `/META-INF/maven/site-tools.xml`.
@@ -113,17 +113,17 @@ See [`AbstractSiteRenderingMojo.createSiteRenderingContext(...)`](/plugins/maven
 
 ${esc.h}${esc.h}# Site Template
 
-When Velocity is processing the site template \(be it from skin or local template\), there are a few complementary variables available that give access to information taken from document being merged into the template:
+When Velocity is processing the site template (be it from skin or local template), there are a few complementary variables available that give access to information taken from document being merged into the template:
 
 |Variable|Type|Description|
 |:---|:---|:---|
-|`authors`|`List<String>`|A list of authors from the source document. If not set is equal to `scmModifiedAuthor` \(only available if artifact [`doxia-site-scm-context`](../doxia-site-scm-context/) is on the classpath\).|
+|`authors`|`List<String>`|A list of authors from the source document. If not set is equal to `scmModifiedAuthor` (only available if artifact [`doxia-site-scm-context`](../doxia-site-scm-context/) is on the classpath).|
 |`bodyContent`|`String`|HTML body content of the Doxia generated output.|
-|`documentDate`|`String`|The date specified in the source document: semantics has to be chosen by document writer \(document creation date, or document last modification date, or ...\), and format is not enforced. If not set is equal to `scmModifiedDate` \(only available if artifact [`doxia-site-scm-context`](../doxia-site-scm-context/) is on the classpath\).|
+|`documentDate`|`String`|The date specified in the source document: semantics has to be chosen by document writer (document creation date, or document last modification date, or ...), and format is not enforced. If not set is equal to `scmModifiedDate` (only available if artifact [`doxia-site-scm-context`](../doxia-site-scm-context/) is on the classpath).|
 |`headContent`|`String`|HTML head content of the Doxia generated output.|
 |`shortTitle`|`String`|The title of the document, excluding the project or site name.|
 |`title`|`String`|The title of the document, including the project or site name.|
-|`docRenderingContext`|[`DocumentRenderingContext`](./apidocs/org/apache/maven/doxia/siterenderer/DocumentRenderingContext.html)|\(since 1\.8\) The document rendering context.|
+|`docRenderingContext`|[`DocumentRenderingContext`](./apidocs/org/apache/maven/doxia/siterenderer/DocumentRenderingContext.html)|(since 1\.8) The document rendering context.|
 
 See [`DefaultSiteRenderer.createSiteTemplateVelocityContext(...)`](./xref/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.html${esc.hash}L616) source for more details.
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.