### PR TITLE
Remove the maven-compat test dependency

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -155,12 +155,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
       <version>${resolverVersion}</version>

--- a/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/stubs/SiteToolMavenProjectStub.java
+++ b/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/stubs/SiteToolMavenProjectStub.java
@@ -27,7 +27,8 @@ import java.util.Properties;
 
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.DefaultArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.DistributionManagement;
@@ -107,8 +108,21 @@ public class SiteToolMavenProjectStub extends MavenProjectStub {
 
     /** {@inheritDoc} */
     public List<ArtifactRepository> getRemoteArtifactRepositories() {
-        ArtifactRepository repository = new DefaultArtifactRepository(
-                "central", "https://repo1.maven.org/maven2", new DefaultRepositoryLayout());
+        // MavenArtifactRepository stores the policies verbatim, where the DefaultArtifactRepository this
+        // replaces substituted these same defaults for nulls. Passing null here compiles but leaves the
+        // repository unusable to anything that validates its policies.
+        ArtifactRepository repository = new MavenArtifactRepository(
+                "central",
+                "https://repo1.maven.org/maven2",
+                new DefaultRepositoryLayout(),
+                new ArtifactRepositoryPolicy(
+                        true,
+                        ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                        ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE),
+                new ArtifactRepositoryPolicy(
+                        true,
+                        ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                        ArtifactRepositoryPolicy.CHECKSUM_POLICY_IGNORE));
 
         return Collections.singletonList(repository);
     }


### PR DESCRIPTION
The only thing in `doxia-sitetools` reaching into `maven-compat` was a test stub building a remote repository with `DefaultArtifactRepository`. `MavenArtifactRepository` in `maven-artifact` does the same job, so the dependency goes.

### The two are not interchangeable, and the difference is quiet

`DefaultArtifactRepository`'s five-argument constructor **substitutes default policies when handed null**. `MavenArtifactRepository` stores the null. So this compiles:

```java
new MavenArtifactRepository(id, url, layout, null, null)
```

and then fails at runtime, but only where something validates the policies:

```
Invalid artifact repository: Cannot invoke
"ArtifactRepositoryPolicy.isEnabled()" because "policy" is null
```

The policies passed here are the ones the old class was supplying all along — `enabled`, `UPDATE_POLICY_ALWAYS`, `CHECKSUM_POLICY_IGNORE`, confirmed against the bytecode of the constructor being replaced — so behaviour is unchanged.

Worth flagging for anyone making the same swap elsewhere: whether the null form fails depends entirely on the call site. In `maven-release-manager`'s `AbstractReleaseTestCase`, the *local* repository has been built with nulls in existing code for years and is fine, while the remote repositories a few lines later are validated and are not. Same class, same constructor, one safe call site and one not. Trying the null form there produced 315 test errors out of 769.

### Verification

The whole `doxia-sitetools` reactor builds and passes with the change, unchanged from before it.

Part of a wider survey of which Maven projects still declare `maven-compat` versus which genuinely use it — several declare it and never touch it, while others depend on it in ways that are not trivially removable.
