### PR TITLE
Drop the version.maven-site-plugin property the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@ under the License.
     <l10nPluginVersion>1.2.0</l10nPluginVersion>
     <maven.site.path>doxia-sitetools-archives/doxia-sitetools-LATEST</maven.site.path>
     <project.build.outputTimestamp>2026-03-31T15:50:32Z</project.build.outputTimestamp>
-    <version.maven-site-plugin>3.22.0</version.maven-site-plugin>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
`org.apache:apache:39` already sets `version.maven-site-plugin` to **3.22.0** — the identical value — so the local property restates what is inherited and simply has to be kept in step with the parent by hand.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything. `mvn help:effective-pom` still resolves maven-site-plugin to 3.22.0 with the line gone.

Generated-by: Claude Opus 5 (1M context)
