### PR TITLE
Expose MultiPageSinkFactory so reports can render subpages outside the site

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSinkFactory.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSinkFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer.sink;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.SinkFactory;
+import org.apache.maven.doxia.siterenderer.DocumentRenderingContext;
+import org.codehaus.plexus.util.PathTool;
+
+/**
+ * The sink factory to hand to a report that generates more than one page, so that each page it asks for is
+ * rendered into the site the same way the report's main page is.
+ * <p>
+ * Every {@link #createSink(File, String)} call derives a {@link DocumentRenderingContext} from the main one and
+ * records the resulting {@link MultiPageSubSink}. Once the report has run, the caller merges the main sink into
+ * the site and then does the same for each sink in {@link #getSinks()}, writing it to its own
+ * {@link MultiPageSubSink#getOutputDirectory() output directory} and
+ * {@link MultiPageSubSink#getOutputName() output name}.
+ * <p>
+ * The document name of a subpage is its path relative to the report output directory, with the filename extension
+ * removed, since the site renderer appends <code>.html</code> itself. A name carrying no extension is taken as-is.
+ *
+ * @see MultiPageSubSink
+ * @since 2.2.0
+ */
+public class MultiPageSinkFactory implements SinkFactory {
+    private static final String UNSUPPORTED_MESSAGE =
+            "Only createSink(File, String) is supported by MultiPageSinkFactory.";
+
+    /**
+     * The directory the report writes its pages to, which subpage paths are relative to
+     */
+    private final File reportOutputDirectory;
+
+    /**
+     * The main DocumentRenderingContext, which is the base for the DocumentRenderingContext of subpages
+     */
+    private final DocumentRenderingContext docRenderingContext;
+
+    /**
+     * List of sinks (subpages) associated to this report
+     */
+    private final List<MultiPageSubSink> sinks = new ArrayList<>();
+
+    /**
+     * @param reportOutputDirectory the directory the report writes its pages to, in general
+     *            <code>MavenReport.getReportOutputDirectory()</code>
+     * @param docRenderingContext the rendering context of the report's main page
+     */
+    public MultiPageSinkFactory(File reportOutputDirectory, DocumentRenderingContext docRenderingContext) {
+        this.reportOutputDirectory = reportOutputDirectory;
+        this.docRenderingContext = docRenderingContext;
+    }
+
+    @Override
+    public Sink createSink(File outputDirectory, String outputName) {
+        // Create a new document rendering context, similar to the main one, but with a different output name
+        String document = PathTool.getRelativeFilePath(
+                reportOutputDirectory.getPath(), new File(outputDirectory, outputName).getPath());
+        // Remove the .html suffix since we know that we are in Site Renderer context
+        int extensionStart = document.lastIndexOf('.');
+        if (extensionStart >= 0) {
+            document = document.substring(0, extensionStart);
+        }
+
+        DocumentRenderingContext subSinkContext = new DocumentRenderingContext(
+                docRenderingContext.getBasedir(), document, docRenderingContext.getGenerator());
+
+        // Create a sink for this subpage, based on this new document rendering context
+        MultiPageSubSink sink = new MultiPageSubSink(outputDirectory, outputName, subSinkContext);
+
+        // Add it to the list of sinks associated to this report
+        sinks.add(sink);
+
+        return sink;
+    }
+
+    @Override
+    public Sink createSink(File outputDir, String outputName, String encoding) {
+        throw new UnsupportedOperationException(
+                UNSUPPORTED_MESSAGE + " The encoding is always determined by the site rendering context.");
+    }
+
+    @Override
+    public Sink createSink(OutputStream out) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE + " OutputStream based sinks are not supported.");
+    }
+
+    @Override
+    public Sink createSink(OutputStream out, String encoding) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE + " OutputStream based sinks are not supported.");
+    }
+
+    /**
+     * Get the subpage sinks handed out so far, in the order the report asked for them.
+     *
+     * @return the sinks, empty if the report turned out to produce a single page only
+     */
+    public List<MultiPageSubSink> getSinks() {
+        return Collections.unmodifiableList(sinks);
+    }
+}

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSubSink.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSubSink.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer.sink;
+
+import java.io.File;
+
+import org.apache.maven.doxia.siterenderer.DocumentRenderingContext;
+
+/**
+ * A sink for one subpage of a multipage report, remembering where the subpage is meant to be written to.
+ * Instances are handed out by {@link MultiPageSinkFactory}, which is also the only thing that creates them.
+ *
+ * @see MultiPageSinkFactory
+ * @since 2.2.0
+ */
+public class MultiPageSubSink extends SiteRendererSink {
+    private final File outputDirectory;
+
+    private final String outputName;
+
+    MultiPageSubSink(File outputDirectory, String outputName, DocumentRenderingContext docRenderingContext) {
+        super(docRenderingContext);
+        this.outputDirectory = outputDirectory;
+        this.outputName = outputName;
+    }
+
+    /**
+     * Get the file name the subpage is to be written to, relative to {@link #getOutputDirectory()}.
+     *
+     * @return the file name, as the report passed it to {@link MultiPageSinkFactory#createSink(File, String)}
+     */
+    public String getOutputName() {
+        return outputName;
+    }
+
+    /**
+     * Get the directory the subpage is to be written to. It need not exist yet.
+     *
+     * @return the directory, as the report passed it to {@link MultiPageSinkFactory#createSink(File, String)}
+     */
+    public File getOutputDirectory() {
+        return outputDirectory;
+    }
+}

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSinkFactoryTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/sink/MultiPageSinkFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer.sink;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import org.apache.maven.doxia.siterenderer.DocumentRenderingContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MultiPageSinkFactoryTest {
+    private static final File BASEDIR = new File("target/test-basedir");
+
+    private static final File REPORT_OUTPUT_DIRECTORY = new File(BASEDIR, "site");
+
+    private MultiPageSinkFactory newSinkFactory() {
+        DocumentRenderingContext mainContext = new DocumentRenderingContext(BASEDIR, "main-page", "generator");
+        return new MultiPageSinkFactory(REPORT_OUTPUT_DIRECTORY, mainContext);
+    }
+
+    @Test
+    void noSubpagesUntilTheReportAsksForOne() {
+        assertTrue(newSinkFactory().getSinks().isEmpty());
+    }
+
+    @Test
+    void subpageKeepsWhereItIsToBeWritten() {
+        MultiPageSinkFactory sinkFactory = newSinkFactory();
+
+        sinkFactory.createSink(REPORT_OUTPUT_DIRECTORY, "subpage.html");
+
+        assertEquals(1, sinkFactory.getSinks().size());
+        MultiPageSubSink subSink = sinkFactory.getSinks().get(0);
+        assertEquals(REPORT_OUTPUT_DIRECTORY, subSink.getOutputDirectory());
+        assertEquals("subpage.html", subSink.getOutputName());
+    }
+
+    @Test
+    void subpageDocumentIsRelativeToTheReportOutputDirectory() {
+        MultiPageSinkFactory sinkFactory = newSinkFactory();
+
+        sinkFactory.createSink(new File(REPORT_OUTPUT_DIRECTORY, "nested"), "subpage.html");
+
+        assertEquals(
+                "nested/subpage.html",
+                sinkFactory.getSinks().get(0).getRenderingContext().getOutputPath());
+    }
+
+    @Test
+    void subpageWithoutAnExtensionIsTakenAsIs() {
+        MultiPageSinkFactory sinkFactory = newSinkFactory();
+
+        sinkFactory.createSink(REPORT_OUTPUT_DIRECTORY, "subpage");
+
+        assertEquals(
+                "subpage.html",
+                sinkFactory.getSinks().get(0).getRenderingContext().getOutputPath());
+    }
+
+    @Test
+    void onlyTheFileBasedFactoryMethodIsSupported() {
+        MultiPageSinkFactory sinkFactory = newSinkFactory();
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> sinkFactory.createSink(REPORT_OUTPUT_DIRECTORY, "subpage.html", "UTF-8"));
+        assertThrows(UnsupportedOperationException.class, () -> sinkFactory.createSink(new ByteArrayOutputStream()));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> sinkFactory.createSink(new ByteArrayOutputStream(), "UTF-8"));
+        assertTrue(sinkFactory.getSinks().isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #671.

`MultiPageSinkFactory` takes the report output directory instead of a `MavenReport`, which is the only thing the site plugin's copy uses it for and the only thing that would have dragged Maven Reporting API into doxia-site-renderer.

`MultiPageSubSink` has a package-private constructor: the factory is the only thing that creates one.

Whether to unify the two consumers' "merge each sub-sink into the site" loops is left alone — they differ in logging and in where they take the output encoding from, and that is a separate call.

Marked `@since 2.2.0`, since a new public type is not a patch release; happy to change it if the next release is numbered differently.

Both consumers switch over only once this is released, so nothing breaks in the meantime:

- maven-site-plugin `ReportDocumentRenderer` — delete both nested classes
- maven-reporting-impl `AbstractMavenReport` — delete the copy added in apache/maven-reporting-impl#244, which carries a TODO pointing here

Verified: `mvn -pl doxia-site-renderer test` → 21 passed. Reinstating the unguarded `substring` fails `subpageWithoutAnExtensionIsTakenAsIs` with the `StringIndexOutOfBoundsException` from #671.

<sub>Drafted with Claude — please verify</sub>
