### PR TITLE
Use resolver's HTTP transport in the integration-tools tests instead of wagon

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -168,21 +168,9 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <artifactId>maven-resolver-transport-http</artifactId>
       <version>${resolverVersion}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http</artifactId>
-      <version>${wagonVersion}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@ under the License.
     <doxiaVersion>2.1.0</doxiaVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <resolverVersion>1.4.1</resolverVersion>
-    <wagonVersion>3.5.3</wagonVersion>
     <l10nPluginVersion>1.2.0</l10nPluginVersion>
     <maven.site.path>doxia-sitetools-archives/doxia-sitetools-LATEST</maven.site.path>
     <project.build.outputTimestamp>2026-03-31T15:50:32Z</project.build.outputTimestamp>


### PR DESCRIPTION
The tests build their own `RepositorySystemSession`, so a transport has to be on the test classpath for skin and site-descriptor resolution to reach central at all — resolver’s own HTTP transport covers that without the wagon pair, and `wagonVersion` has no other user.

Emptying `target/local-repo` before the run confirms the artifacts still come down rather than being served from a warm cache.

This change was created with AI assistance.