### PR TITLE
Drop the unused maven-plugin-testing-harness test dependency

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -143,18 +143,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>3.5.1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
       <version>${resolverVersion}</version>


### PR DESCRIPTION
Nothing in the reactor touches the harness — no `AbstractMojoTestCase`, no `MojoRule`, no `org.apache.maven.plugin.testing` import anywhere. The stub that looks like it might need one, `MavenProjectStub`, extends `MavenProject` directly.

The only thing it contributed transitively was `mockito-core`, which this module neither declares nor uses:

```
+- org.apache.maven.plugin-testing:maven-plugin-testing-harness:jar:3.5.1:test
|  \- org.mockito:mockito-core:jar:4.11.0:test
```

It was also carrying the last `plexus-container-default` reference in the stack, as an exclusion on itself. With wagon gone in #673 and `maven-compat` in #666, removing this leaves no module in any of the four repositories resolving `plexus-container-default`, and drops a Maven 3-era test harness along with it.

Verified: `mvn clean verify` → 68 tests, 0 failures (including the 11 in `SiteToolTest` that resolve from Central); `dependency:tree -Dincludes=org.codehaus.plexus:plexus-container-default` matches nothing in the reactor.

*This change was created with AI assistance.*