### PR TITLE
Gate the public API on binary compatibility

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -167,6 +167,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
   <reporting>
     <plugins>
       <plugin>

--- a/doxia-site-model/pom.xml
+++ b/doxia-site-model/pom.xml
@@ -64,6 +64,10 @@ under the License.
   <build>
     <plugins>
       <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
         <configuration>

--- a/doxia-site-renderer/pom.xml
+++ b/doxia-site-renderer/pom.xml
@@ -224,6 +224,12 @@ under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
   <profiles>
     <profile>

--- a/doxia-skin-model/pom.xml
+++ b/doxia-skin-model/pom.xml
@@ -42,6 +42,10 @@ under the License.
   <build>
     <plugins>
       <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.modello</groupId>
         <artifactId>modello-maven-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -196,16 +196,35 @@ under the License.
     </resources>
     <pluginManagement>
       <plugins>
-        <!-- TODO need to upgrade to last version or Maven parent version -->
-        <!--
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>clirr-maven-plugin</artifactId>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>0.26.1</version>
           <configuration>
-            <comparisonVersion>1.9</comparisonVersion>
+            <parameter>
+              <ignoreNonResolvableArtifacts>false</ignoreNonResolvableArtifacts>
+              <ignoreMissingOldVersion>false</ignoreMissingOldVersion>
+              <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+              <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+            </parameter>
+            <oldVersion>
+              <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>${project.artifactId}</artifactId>
+                <!-- keep binary compatibility among the major version 2.x-->
+                <version>2.0.0</version>
+              </dependency>
+            </oldVersion>
           </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>cmp</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
         </plugin>
-         -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
@@ -241,23 +260,6 @@ under the License.
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
       </plugin>
-      <!--
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <excludes>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin> -->
     </plugins>
   </build>
 


### PR DESCRIPTION
Sitetools has no API compatibility check at all. The `clirr-maven-plugin` configuration is commented out in both `pluginManagement` and `build`, carries a "TODO need to upgrade" note, and compares against 1.9 — so nothing has been guarding the public API across the whole 2.x line, while doxia has enforced japicmp against a 2.0.0 baseline for some time.

This applies the same configuration and drops the dead clirr blocks.

Gated are the four modules that were already published in 2.0.0. `doxia-site-scm-context` is deliberately left out: it first shipped in 2.1.0, so there is no 2.0.0 artifact to compare against and `ignoreMissingOldVersion` is `false`.

The current tree turns out to be binary compatible with 2.0.0 already, so this records the existing state rather than changing it — no exclusions were needed.

Verified two ways, because a compatibility gate that never fails is worse than none: `mvn clean verify` passes across all six modules, and deleting `SiteRenderingContext#addSiteDirectory(File)` makes the build fail with `SiteRenderingContext.addSiteDirectory(java.io.File):METHOD_REMOVED`.

*This change was created with AI assistance.*