### PR TITLE
Let an offline build skip the tests that need a repository

### DIFF
--- a/doxia-integration-tools/pom.xml
+++ b/doxia-integration-tools/pom.xml
@@ -167,6 +167,21 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- SiteToolTest builds its own repository session, which never sees this otherwise.
+               Passed on the command line because systemPropertyVariables takes Strings only, and
+               settings.offline interpolates as a Boolean. -->
+          <argLine>-Ddoxia.test.offline=${settings.offline}</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <reporting>
     <plugins>
       <plugin>

--- a/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/SiteToolTest.java
+++ b/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/SiteToolTest.java
@@ -51,6 +51,7 @@ import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.codehaus.plexus.testing.PlexusExtension.getTestFile;
@@ -61,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
@@ -71,6 +73,18 @@ class SiteToolTest {
 
     @Inject
     private DefaultSiteTool tool;
+
+    /**
+     * These tests resolve the skin and parent site descriptors from Central. The session below is
+     * built by hand, so it never sees Maven's own offline setting; the build passes it in as a system
+     * property and the tests stand aside when it is set.
+     */
+    @BeforeEach
+    void requireNetwork() {
+        assumeFalse(
+                Boolean.getBoolean("doxia.test.offline"),
+                "resolves the skin and site descriptors from a remote repository");
+    }
 
     /**
      * @return the local repo directory.


### PR DESCRIPTION
`SiteToolTest` resolves the Fluido skin and parent site descriptors from Central. It assembles its own `RepositorySystemSession`, so Maven's offline setting never reaches it — running `mvn -o` still went to the network and still populated `target/local-repo`, which I confirmed by wiping that directory and watching six files reappear under `-o`. An offline build could not pass.

The build now hands the setting to the test JVM and the class stands aside when it is set. That goes through `argLine` rather than `systemPropertyVariables`, because the latter takes Strings and `settings.offline` interpolates as a `Boolean` — surefire rejects it with `Cannot assign configuration entry ... of type java.lang.Boolean to property of type java.lang.String`.

Verified: online, all 11 tests run and none skip; with `-o`, all 11 skip and nothing is written to `target/local-repo`.

Note this adds a `<build>` section to `doxia-integration-tools/pom.xml`, which #677 also does — whichever lands second will want a trivial rebase. Happy to do that once the other merges.

*This change was created with AI assistance.*