### PR TITLE
Stop routing through the deprecated Reader and Writer factories

### DIFF
--- a/doxia-integration-tools/src/main/java/org/apache/maven/doxia/tools/DefaultSiteTool.java
+++ b/doxia-integration-tools/src/main/java/org/apache/maven/doxia/tools/DefaultSiteTool.java
@@ -80,8 +80,8 @@ import org.codehaus.plexus.interpolation.PrefixedObjectValueSource;
 import org.codehaus.plexus.interpolation.PrefixedPropertiesValueSource;
 import org.codehaus.plexus.interpolation.RegexBasedInterpolator;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.MXParser;
 import org.codehaus.plexus.util.xml.pull.XmlPullParser;
@@ -1055,7 +1055,7 @@ public class DefaultSiteTool implements SiteTool {
                 LOGGER.debug("Reading" + (depth == 0 ? "" : (" parent level " + depth)) + " site descriptor from "
                         + siteDescriptor);
 
-                siteDescriptorReader = ReaderFactory.newXmlReader(siteDescriptor);
+                siteDescriptorReader = new XmlStreamReader(siteDescriptor);
 
                 String siteDescriptorContent = IOUtil.toString(siteDescriptorReader);
 
@@ -1355,7 +1355,7 @@ public class DefaultSiteTool implements SiteTool {
 
         Reader reader = null;
         try {
-            reader = ReaderFactory.newXmlReader(getClass().getResourceAsStream("/default-site.xml"));
+            reader = new XmlStreamReader(getClass().getResourceAsStream("/default-site.xml"));
             siteDescriptorContent = IOUtil.toString(reader);
         } catch (IOException e) {
             throw new SiteToolException("Error reading default site descriptor", e);

--- a/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/SiteToolTest.java
+++ b/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/SiteToolTest.java
@@ -46,7 +46,7 @@ import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.WriterFactory;
+import org.codehaus.plexus.util.xml.XmlStreamWriter;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
@@ -634,7 +634,7 @@ class SiteToolTest {
     }
 
     private void writeModel(SiteModel model, String to) throws Exception {
-        Writer writer = WriterFactory.newXmlWriter(getTestFile("target/test-classes/" + to));
+        Writer writer = new XmlStreamWriter(getTestFile("target/test-classes/" + to));
         try {
             new SiteXpp3Writer().write(writer, model);
         } finally {

--- a/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/stubs/MavenProjectStub.java
+++ b/doxia-integration-tools/src/test/java/org/apache/maven/doxia/tools/stubs/MavenProjectStub.java
@@ -58,7 +58,7 @@ import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.testing.PlexusExtension;
-import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
@@ -187,7 +187,7 @@ public class MavenProjectStub extends MavenProject {
             pomFile = new File(getBasedir(), pomFile.getPath());
         }
         try {
-            setModel(new MavenXpp3Reader().read(ReaderFactory.newXmlReader(pomFile)));
+            setModel(new MavenXpp3Reader().read(new XmlStreamReader(pomFile)));
         } catch (IOException e) {
             throw new RuntimeException("Failed to read POM file: " + pomFile, e);
         } catch (XmlPullParserException e) {

--- a/doxia-site-model/src/test/java/org/apache/maven/doxia/site/inheritance/SiteModelInheritanceAssemblerTest.java
+++ b/doxia-site-model/src/test/java/org/apache/maven/doxia/site/inheritance/SiteModelInheritanceAssemblerTest.java
@@ -31,7 +31,7 @@ import org.apache.maven.doxia.site.Menu;
 import org.apache.maven.doxia.site.SiteModel;
 import org.apache.maven.doxia.site.io.xpp3.SiteXpp3Reader;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.Test;
 
@@ -932,7 +932,7 @@ class SiteModelInheritanceAssemblerTest {
     private SiteModel readModel(String name) throws IOException, XmlPullParserException {
         Reader reader = null;
         try {
-            reader = ReaderFactory.newXmlReader(getClass().getResourceAsStream("/" + name));
+            reader = new XmlStreamReader(getClass().getResourceAsStream("/" + name));
             return new SiteXpp3Reader().read(reader);
         } finally {
             IOUtil.close(reader);

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -27,13 +27,16 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -107,9 +110,8 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.PathTool;
-import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.WriterFactory;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.codehaus.plexus.velocity.VelocityComponent;
 import org.slf4j.Logger;
@@ -390,7 +392,8 @@ public class DefaultSiteRenderer implements Renderer {
                 Writer writer = null;
                 try {
                     if (!docRenderer.isExternalReport()) {
-                        writer = WriterFactory.newWriter(outputFile, siteRenderingContext.getOutputEncoding());
+                        writer = new OutputStreamWriter(
+                                Files.newOutputStream(outputFile.toPath()), siteRenderingContext.getOutputEncoding());
                     }
                     docRenderer.renderDocument(writer, this, siteRenderingContext);
                 } finally {
@@ -459,7 +462,7 @@ public class DefaultSiteRenderer implements Renderer {
             } else {
                 switch (parser.getType()) {
                     case Parser.XML_TYPE:
-                        reader = ReaderFactory.newXmlReader(doc);
+                        reader = new XmlStreamReader(doc);
                         if (siteContext.isValidate()) {
                             reader = validate(reader, resource);
                         }
@@ -468,7 +471,8 @@ public class DefaultSiteRenderer implements Renderer {
                     case Parser.TXT_TYPE:
                     case Parser.UNKNOWN_TYPE:
                     default:
-                        reader = ReaderFactory.newReader(doc, siteContext.getInputEncoding());
+                        reader = new InputStreamReader(
+                                Files.newInputStream(doc.toPath()), siteContext.getInputEncoding());
                 }
             }
 
@@ -930,7 +934,8 @@ public class DefaultSiteRenderer implements Renderer {
             }
             Writer writer = null;
             try {
-                writer = WriterFactory.newWriter(siteCssFile, siteRenderingContext.getOutputEncoding());
+                writer = new OutputStreamWriter(
+                        Files.newOutputStream(siteCssFile.toPath()), siteRenderingContext.getOutputEncoding());
                 // DOXIA-290...the file should not be 0 bytes.
                 writer.write("/* You can override this file with your own styles */");
             } finally {

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
@@ -19,6 +19,7 @@
 package org.apache.maven.doxia.siterenderer;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,8 +34,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.site.SiteModel;
 import org.apache.maven.doxia.site.skin.SkinModel;
-import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.WriterFactory;
 
 /**
  * Context for a site rendering.
@@ -110,9 +109,9 @@ public class SiteRenderingContext {
         }
     }
 
-    private String inputEncoding = ReaderFactory.FILE_ENCODING;
+    private String inputEncoding = System.getProperty("file.encoding");
 
-    private String outputEncoding = WriterFactory.UTF_8;
+    private String outputEncoding = StandardCharsets.UTF_8.name();
 
     private String templateName;
 

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DefaultSiteRendererTest.java
@@ -62,9 +62,9 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
-import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -496,7 +496,7 @@ public class DefaultSiteRendererTest {
 
         Reader reader = null;
         try {
-            reader = ReaderFactory.newXmlReader(macro);
+            reader = new XmlStreamReader(macro);
             String content = IOUtil.toString(reader);
             assertEquals(-1, content.indexOf("</macro>"));
         } finally {
@@ -638,7 +638,7 @@ public class DefaultSiteRendererTest {
             for (String file : l) {
                 file = file == null || file.isEmpty() ? file : file.replace("\\", "/");
 
-                Reader reader = ReaderFactory.newXmlReader(new File(file));
+                Reader reader = new XmlStreamReader(new File(file));
                 try {
                     testDocs.put(file, IOUtil.toString(reader));
                 } finally {


### PR DESCRIPTION
`ReaderFactory` and `WriterFactory` are deprecated at class level in plexus-utils 4. Their javadoc points at the XML stream classes for XML and at the JDK for everything else — which is exactly what they do internally, so the substitutions are the factory bodies themselves:

| was | now |
|---|---|
| `newXmlReader(x)` | `new XmlStreamReader(x)` |
| `newReader(file, enc)` | `new InputStreamReader(Files.newInputStream(..), enc)` |
| `newWriter(file, enc)` | `new OutputStreamWriter(Files.newOutputStream(..), enc)` |
| `newXmlWriter(file)` | `new XmlStreamWriter(file)` |
| `UTF_8` / `FILE_ENCODING` | `StandardCharsets.UTF_8.name()` / `file.encoding` |

The concern with a change like this is BOM and XML encoding detection, so worth being explicit about why that is safe here: `XmlStreamReader` and `XmlStreamWriter` are the very classes the factories construct and return, and they come from `plexus-xml`, which the stack keeps. The detection is the same code, not a reimplementation. Their plexus-xml versions also carry no deprecated members, unlike the Commons IO equivalents whose constructors are all deprecated in favour of builders.

`plexus-utils` stays a dependency regardless — `PathTool`, `SelectorUtils`, `Os` and `DirectoryScanner` are unaffected by this.

Verified: `mvn clean verify` → 68 tests pass, and the HTML and CSS produced by the renderer tests are byte-identical to the same build from master. That diff covers both changed writer paths, since `css/site.css` is written by one of them.

*This change was created with AI assistance.*