### PR TITLE
Draft releases against the resolved version, not the next minor

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,4 +16,4 @@
 # under the License.
 
 _extends: maven-gh-actions-shared
-tag-template: doxia-sitetools-$NEXT_MINOR_VERSION
+tag-template: doxia-sitetools-$RESOLVED_VERSION


### PR DESCRIPTION
The tag template uses `$NEXT_MINOR_VERSION` while the draft name comes from the resolved version, so every draft disagrees with itself. The current one is named **2.1.1** but tagged **doxia-sitetools-2.2.0**.

Released tags follow the resolved version — `doxia-sitetools-2.1.0`, `doxia-sitetools-2.0.0` — and `maven-doxia` already uses exactly this template. Editing the draft by hand would not have helped; release-drafter regenerates it on every push to master, which is why the mismatch keeps coming back.

Unrelated but worth a look while you are in there: the repository currently has **two** draft releases with the same name and tag (ids 371808208 and 307984316). Deleting one is not something I wanted to do unasked.

*This change was created with AI assistance.*