### PR TITLE
Stop Dependabot proposing resolver upgrades on their own

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  ignore:
+    # resolverVersion is paired with mavenVersion: Maven 3.6.3 ships resolver 1.4.1.
+    # Raising one without the other builds against API the minimum Maven does not have.
+    - dependency-name: "org.apache.maven.resolver:*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
`resolverVersion` is paired with `mavenVersion`, not independent of it. Maven 3.6.3 declares resolver **1.4.1** in its own pom, and Maven 3.9.9 declares **1.9.22** — so the current pairing of `mavenVersion=3.6.3` with `resolverVersion=1.4.1` is exactly the resolver the declared minimum Maven supplies.

That matters because `maven-resolver-api` is `provided` scope: the runtime supplies it. Building against a newer resolver than the minimum Maven ships lets API that is absent there compile cleanly and fail at runtime instead.

Dependabot cannot see the coupling and has proposed the bump on its own, most recently in #681, where it took all eleven `SiteToolTest` cases with it — resolver 1.9.x restructured `DefaultRepositorySystem` to constructor injection, so Sisu could no longer satisfy `org.eclipse.aether.RepositorySystem`.

Moving to resolver 1.9.x is a decision about the supported Maven baseline, and belongs in a change that raises `mavenVersion` alongside it rather than arriving as routine dependency hygiene.

*This change was created with AI assistance.*