### PR TITLE
Derive breadcrumbs from menu hierarchy when none are declared

### DIFF
--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/DefaultSiteRenderer.java
@@ -70,6 +70,7 @@ import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.parser.manager.ParserNotFoundException;
 import org.apache.maven.doxia.parser.module.ParserModule;
 import org.apache.maven.doxia.parser.module.ParserModuleManager;
+import org.apache.maven.doxia.site.LinkItem;
 import org.apache.maven.doxia.site.SiteModel;
 import org.apache.maven.doxia.site.skin.ResourceCondition;
 import org.apache.maven.doxia.site.skin.SkinModel;
@@ -609,9 +610,24 @@ public class DefaultSiteRenderer implements Renderer {
                 }
             }
         }
-        context.put("site", siteRenderingContext.getSiteModel());
+        SiteModel siteModel = siteRenderingContext.getSiteModel();
+        if (docRenderingContext != null
+                && siteRenderingContext.isDeriveBreadcrumbsFromMenu()
+                && siteModel != null
+                && siteModel.getBody() != null
+                && siteModel.getBody().getBreadcrumbs().isEmpty()) {
+            List<LinkItem> derivedBreadcrumbs =
+                    MenuBreadcrumbs.derive(siteModel.getMenus(), docRenderingContext.getOutputPath());
+            if (!derivedBreadcrumbs.isEmpty()) {
+                // clone: the site model is shared across all documents of this site rendering,
+                // and the derived trail is specific to this one document
+                siteModel = siteModel.clone();
+                siteModel.getBody().setBreadcrumbs(derivedBreadcrumbs);
+            }
+        }
+        context.put("site", siteModel);
         // TODO Deprecated -- will be removed!
-        context.put("decoration", siteRenderingContext.getSiteModel());
+        context.put("decoration", siteModel);
 
         context.put("locale", siteRenderingContext.getLocale());
         context.put("supportedLocales", Collections.unmodifiableList(siteRenderingContext.getSiteLocales()));

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/MenuBreadcrumbs.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/MenuBreadcrumbs.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.doxia.site.LinkItem;
+import org.apache.maven.doxia.site.Menu;
+import org.apache.maven.doxia.site.MenuItem;
+import org.apache.maven.doxia.site.SiteUtils;
+
+/**
+ * Derives a breadcrumb trail for a document from the site descriptor's menu hierarchy, for use on
+ * documents which do not declare an explicit <code>&lt;breadcrumbs&gt;</code> element.
+ *
+ * <p>This only walks the {@link Menu#getItems()} it is given: any <code>ref</code>,
+ * <code>inherit</code> or <code>inheritAsRef</code> attribute on a {@link Menu} is expected to
+ * already be resolved into concrete {@link MenuItem}s by the caller (as done by the Maven Site
+ * Plugin's site tool before the site model reaches the renderer). A menu which is still an
+ * unresolved reference simply contributes no items to search.</p>
+ *
+ * @since 2.1.1
+ */
+class MenuBreadcrumbs {
+
+    private MenuBreadcrumbs() {}
+
+    /**
+     * Locate {@code outputPath} among the {@code href} of the given menus' items (searched
+     * recursively through nested {@code <item>} elements), and build a breadcrumb trail from the
+     * {@code name} of the enclosing menu followed by the {@code name} of each enclosing item, from
+     * the outermost to the innermost. The located item itself is not included in the trail, matching
+     * how an explicit <code>&lt;breadcrumbs&gt;</code> element is conventionally written (listing only
+     * the ancestors of the current page).
+     *
+     * @param menus the site's menus, not null
+     * @param outputPath the current document's output path, relative to the site root (see
+     *      {@link DocumentRenderingContext#getOutputPath()}), not null
+     * @return the derived breadcrumb trail, outermost first; empty if {@code outputPath} is not found
+     *      in any menu item
+     */
+    static List<LinkItem> derive(List<Menu> menus, String outputPath) {
+        for (Menu menu : menus) {
+            List<LinkItem> trail = new ArrayList<>();
+            if (menu.getName() != null) {
+                LinkItem menuLink = new LinkItem();
+                menuLink.setName(menu.getName());
+                trail.add(menuLink);
+            }
+            if (find(menu.getItems(), outputPath, trail)) {
+                return trail;
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Recursively search {@code items} (and their nested items) for one whose href matches
+     * {@code outputPath}. While descending, every item visited on the current path is appended to
+     * {@code trail}; if the search backtracks without finding a match, those entries are removed
+     * again so that {@code trail} only ever holds ancestors of a found item.
+     */
+    private static boolean find(List<MenuItem> items, String outputPath, List<LinkItem> trail) {
+        if (items == null) {
+            return false;
+        }
+        for (MenuItem item : items) {
+            if (matches(item.getHref(), outputPath)) {
+                return true;
+            }
+
+            int sizeBeforeDescending = trail.size();
+            LinkItem itemLink = new LinkItem();
+            itemLink.setName(item.getName());
+            itemLink.setHref(item.getHref());
+            trail.add(itemLink);
+
+            if (find(item.getItems(), outputPath, trail)) {
+                return true;
+            }
+
+            // this item's branch did not contain outputPath: backtrack
+            while (trail.size() > sizeBeforeDescending) {
+                trail.remove(trail.size() - 1);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compare a menu item's href to the current document's output path. Both are expected to be
+     * relative to the site root: a leading <code>/</code> or <code>./</code> is stripped from the
+     * href before comparison. External links (as recognized by {@link SiteUtils#isLink(String)}) and
+     * hrefs containing a fragment (<code>#</code>) or query never match. This is a conservative,
+     * literal comparison: hrefs written with <code>../</code> segments, or otherwise not relative to
+     * the site root, will not be matched.
+     */
+    private static boolean matches(String href, String outputPath) {
+        if (href == null || href.isEmpty() || SiteUtils.isLink(href)) {
+            return false;
+        }
+        if (href.indexOf('#') >= 0 || href.indexOf('?') >= 0) {
+            return false;
+        }
+        String normalized = href;
+        if (normalized.startsWith("./")) {
+            normalized = normalized.substring(2);
+        } else if (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized.equals(outputPath);
+    }
+}

--- a/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
+++ b/doxia-site-renderer/src/main/java/org/apache/maven/doxia/siterenderer/SiteRenderingContext.java
@@ -139,6 +139,8 @@ public class SiteRenderingContext {
 
     private boolean validate;
 
+    private boolean deriveBreadcrumbsFromMenu;
+
     private Date publishDate;
 
     private File processedContentOutput;
@@ -166,6 +168,29 @@ public class SiteRenderingContext {
      */
     public void setValidate(boolean validate) {
         this.validate = validate;
+    }
+
+    /**
+     * If breadcrumbs should be derived from the site descriptor's menu hierarchy for documents which
+     * declare no explicit <code>&lt;breadcrumbs&gt;</code> element.
+     * By default this is switched off: a document without an explicit <code>&lt;breadcrumbs&gt;</code>
+     * element then renders with an empty breadcrumb trail, as it always has.
+     *
+     * @return true if breadcrumbs should be derived from the menu hierarchy.
+     * @since 2.1.1
+     */
+    public boolean isDeriveBreadcrumbsFromMenu() {
+        return deriveBreadcrumbsFromMenu;
+    }
+
+    /**
+     * Switch on/off deriving breadcrumbs from the site descriptor's menu hierarchy.
+     *
+     * @param deriveBreadcrumbsFromMenu true to switch on breadcrumb derivation.
+     * @since 2.1.1
+     */
+    public void setDeriveBreadcrumbsFromMenu(boolean deriveBreadcrumbsFromMenu) {
+        this.deriveBreadcrumbsFromMenu = deriveBreadcrumbsFromMenu;
     }
 
     /**

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DeriveBreadcrumbsFromMenuTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/DeriveBreadcrumbsFromMenuTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.doxia.site.Body;
+import org.apache.maven.doxia.site.LinkItem;
+import org.apache.maven.doxia.site.Menu;
+import org.apache.maven.doxia.site.MenuItem;
+import org.apache.maven.doxia.site.SiteModel;
+import org.apache.velocity.context.Context;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.testing.PlexusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@link SiteRenderingContext#isDeriveBreadcrumbsFromMenu()} flag, wired through
+ * {@link DefaultSiteRenderer#createDocumentVelocityContext(DocumentRenderingContext, SiteRenderingContext)}.
+ */
+@PlexusTest
+class DeriveBreadcrumbsFromMenuTest {
+
+    @Inject
+    private PlexusContainer container;
+
+    private DefaultSiteRenderer siteRenderer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        siteRenderer = (DefaultSiteRenderer) container.lookup(SiteRenderer.class);
+    }
+
+    private static SiteModel siteModelWithMenu() {
+        MenuItem userGuide = new MenuItem();
+        userGuide.setName("User Guide");
+        userGuide.setHref("guides/user/index.html");
+
+        Menu menu = new Menu();
+        menu.setName("Documentation");
+        menu.setItems(Collections.singletonList(userGuide));
+
+        Body body = new Body();
+        body.setMenus(Collections.singletonList(menu));
+
+        SiteModel siteModel = new SiteModel();
+        siteModel.setBody(body);
+        return siteModel;
+    }
+
+    private static DocumentRenderingContext documentAt(String outputPathWithoutHtmlExtension) {
+        return new DocumentRenderingContext(new File("."), outputPathWithoutHtmlExtension, "generator");
+    }
+
+    @Test
+    void flagOffLeavesSiteModelUntouched() {
+        SiteModel siteModel = siteModelWithMenu();
+        SiteRenderingContext siteRenderingContext = new SiteRenderingContext();
+        siteRenderingContext.setSiteModel(siteModel);
+        siteRenderingContext.setDeriveBreadcrumbsFromMenu(false);
+
+        Context context =
+                siteRenderer.createDocumentVelocityContext(documentAt("guides/user/index"), siteRenderingContext);
+
+        // the exact same instance is exposed: nothing was derived, nothing was cloned
+        assertSame(siteModel, context.get("site"));
+        assertSame(siteModel, context.get("decoration"));
+        assertTrue(siteModel.getBody().getBreadcrumbs().isEmpty());
+    }
+
+    @Test
+    void flagOnDerivesBreadcrumbsWhenNoneDeclared() {
+        SiteModel siteModel = siteModelWithMenu();
+        SiteRenderingContext siteRenderingContext = new SiteRenderingContext();
+        siteRenderingContext.setSiteModel(siteModel);
+        siteRenderingContext.setDeriveBreadcrumbsFromMenu(true);
+
+        Context context =
+                siteRenderer.createDocumentVelocityContext(documentAt("guides/user/index"), siteRenderingContext);
+
+        SiteModel exposed = (SiteModel) context.get("site");
+        assertSame(exposed, context.get("decoration"));
+
+        List<LinkItem> breadcrumbs = exposed.getBody().getBreadcrumbs();
+        assertEquals(1, breadcrumbs.size());
+        assertEquals("Documentation", breadcrumbs.get(0).getName());
+
+        // the original site model, shared across every document of this rendering, is untouched
+        assertTrue(siteModel.getBody().getBreadcrumbs().isEmpty());
+    }
+
+    @Test
+    void explicitBreadcrumbsWinOverDerivation() {
+        SiteModel siteModel = siteModelWithMenu();
+        LinkItem explicit = new LinkItem();
+        explicit.setName("Explicit crumb");
+        siteModel.getBody().setBreadcrumbs(Collections.singletonList(explicit));
+
+        SiteRenderingContext siteRenderingContext = new SiteRenderingContext();
+        siteRenderingContext.setSiteModel(siteModel);
+        siteRenderingContext.setDeriveBreadcrumbsFromMenu(true);
+
+        Context context =
+                siteRenderer.createDocumentVelocityContext(documentAt("guides/user/index"), siteRenderingContext);
+
+        // the declared breadcrumbs are used as-is, no derivation is attempted, no clone is made
+        assertSame(siteModel, context.get("site"));
+        List<LinkItem> breadcrumbs = ((SiteModel) context.get("site")).getBody().getBreadcrumbs();
+        assertEquals(1, breadcrumbs.size());
+        assertEquals("Explicit crumb", breadcrumbs.get(0).getName());
+    }
+
+    @Test
+    void pageAbsentFromEveryMenuLeavesBreadcrumbsEmpty() {
+        SiteModel siteModel = siteModelWithMenu();
+        SiteRenderingContext siteRenderingContext = new SiteRenderingContext();
+        siteRenderingContext.setSiteModel(siteModel);
+        siteRenderingContext.setDeriveBreadcrumbsFromMenu(true);
+
+        Context context =
+                siteRenderer.createDocumentVelocityContext(documentAt("not-in-any-menu/index"), siteRenderingContext);
+
+        // nothing was found: same instance is exposed, exactly as when the flag is off
+        assertSame(siteModel, context.get("site"));
+        assertTrue(siteModel.getBody().getBreadcrumbs().isEmpty());
+    }
+}

--- a/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/MenuBreadcrumbsTest.java
+++ b/doxia-site-renderer/src/test/java/org/apache/maven/doxia/siterenderer/MenuBreadcrumbsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.doxia.siterenderer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.doxia.site.LinkItem;
+import org.apache.maven.doxia.site.Menu;
+import org.apache.maven.doxia.site.MenuItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MenuBreadcrumbsTest {
+
+    private static MenuItem item(String name, String href, MenuItem... children) {
+        MenuItem item = new MenuItem();
+        item.setName(name);
+        item.setHref(href);
+        if (children.length > 0) {
+            item.setItems(Arrays.asList(children));
+        }
+        return item;
+    }
+
+    private static Menu menu(String name, MenuItem... items) {
+        Menu menu = new Menu();
+        menu.setName(name);
+        menu.setItems(Arrays.asList(items));
+        return menu;
+    }
+
+    private static void assertTrail(List<LinkItem> trail, String... expectedNames) {
+        List<String> names = new ArrayList<>();
+        for (LinkItem link : trail) {
+            names.add(link.getName());
+        }
+        assertEquals(Arrays.asList(expectedNames), names);
+    }
+
+    @Test
+    void oneLevelMatch() {
+        List<Menu> menus = Collections.singletonList(
+                menu("Overview", item("Introduction", "index.html"), item("Download", "download.html")));
+
+        List<LinkItem> trail = MenuBreadcrumbs.derive(menus, "download.html");
+
+        // only the enclosing menu is an ancestor; the matched item itself is not included
+        assertTrail(trail, "Overview");
+        assertEquals(null, trail.get(0).getHref()); // a Menu has no href of its own
+    }
+
+    @Test
+    void nestedItemChainTwoLevelsDeep() {
+        MenuItem userGuide = item("User Guide", "guides/user/index.html");
+        MenuItem guides = item("Guides", null, userGuide);
+        List<Menu> menus = Collections.singletonList(menu("Documentation", guides));
+
+        List<LinkItem> trail = MenuBreadcrumbs.derive(menus, "guides/user/index.html");
+
+        assertTrail(trail, "Documentation", "Guides");
+        assertEquals(null, trail.get(1).getHref()); // "Guides" has no href of its own, only nested items
+    }
+
+    @Test
+    void nestedItemChainThreeLevelsDeep() {
+        MenuItem leaf = item("Configuration", "guides/user/advanced/configuration.html");
+        MenuItem advanced = item("Advanced", "guides/user/advanced/index.html", leaf);
+        MenuItem userGuide = item("User Guide", "guides/user/index.html", advanced);
+        List<Menu> menus = Collections.singletonList(menu("Documentation", userGuide));
+
+        List<LinkItem> trail = MenuBreadcrumbs.derive(menus, "guides/user/advanced/configuration.html");
+
+        assertTrail(trail, "Documentation", "User Guide", "Advanced");
+        assertEquals("guides/user/index.html", trail.get(1).getHref());
+        assertEquals("guides/user/advanced/index.html", trail.get(2).getHref());
+    }
+
+    @Test
+    void pageAbsentFromEveryMenu() {
+        List<Menu> menus = Collections.singletonList(menu("Overview", item("Introduction", "index.html")));
+
+        List<LinkItem> trail = MenuBreadcrumbs.derive(menus, "not-in-any-menu.html");
+
+        assertTrue(trail.isEmpty());
+    }
+
+    @Test
+    void noMenusAtAll() {
+        assertTrue(MenuBreadcrumbs.derive(Collections.emptyList(), "index.html").isEmpty());
+    }
+
+    @Test
+    void secondMenuContainsTheMatch() {
+        List<Menu> menus = Arrays.asList(
+                menu("Overview", item("Introduction", "index.html")),
+                menu("Documentation", item("User Guide", "guides/user/index.html")));
+
+        List<LinkItem> trail = MenuBreadcrumbs.derive(menus, "guides/user/index.html");
+
+        assertTrail(trail, "Documentation");
+    }
+
+    @Test
+    void hrefWithLeadingSlashMatches() {
+        List<Menu> menus = Collections.singletonList(menu("Overview", item("Introduction", "/index.html")));
+
+        assertTrail(MenuBreadcrumbs.derive(menus, "index.html"), "Overview");
+    }
+
+    @Test
+    void hrefWithLeadingDotSlashMatches() {
+        List<Menu> menus = Collections.singletonList(menu("Overview", item("Introduction", "./index.html")));
+
+        assertTrail(MenuBreadcrumbs.derive(menus, "index.html"), "Overview");
+    }
+
+    @Test
+    void externalHrefNeverMatches() {
+        List<Menu> menus = Collections.singletonList(menu("Overview", item("Apache", "https://apache.org/index.html")));
+
+        assertTrue(MenuBreadcrumbs.derive(menus, "index.html").isEmpty());
+    }
+
+    @Test
+    void hrefWithFragmentNeverMatches() {
+        List<Menu> menus = Collections.singletonList(menu("Overview", item("Introduction", "index.html#top")));
+
+        assertTrue(MenuBreadcrumbs.derive(menus, "index.html").isEmpty());
+    }
+
+    @Test
+    void itemWithoutHrefIsStillWalkedForItsChildren() {
+        // a pure category item (no href of its own) whose child matches
+        MenuItem child = item("Child", "category/child.html");
+        MenuItem category = item("Category", null, child);
+        List<Menu> menus = Collections.singletonList(menu("Overview", category));
+
+        assertTrail(MenuBreadcrumbs.derive(menus, "category/child.html"), "Overview", "Category");
+    }
+}


### PR DESCRIPTION
Restores a breadcrumb level that the Doxia site consolidation removed, and makes the trail derivable from structure the descriptor already carries.

## Why

`https://maven.apache.org/doxia/index.html` renders `Apache / Maven / Introduction`. Before the Doxia site moved into `maven-site` (apache/maven-site#1645) it read `Apache / Maven / Doxia / Introduction`. Hervé Boutemy [predicted the loss while planning the move](https://github.com/apache/maven-site/issues/1645#issuecomment-5340818720) and asked for menu-derived breadcrumbs as the fix.

More generally, a site descriptor states its structure twice. `<menu>` says where a page sits in the navigation and `<breadcrumbs>` says where it sits in the trail, with nothing keeping the two in step. Requested in apache/maven-site-plugin#1300.

## What

A new opt-in flag `SiteRenderingContext.deriveBreadcrumbsFromMenu`, default `false`. When it is set and the site declares no explicit `<breadcrumbs>`, the renderer locates the current document among the `<menu><item href>` values and builds a trail from the enclosing menu's name and the chain of enclosing `<item>` names.

Three decisions worth reviewing:

**Per document, not during model assembly.** A breadcrumb depends on which page is rendering, and `SiteModelInheritanceAssembler` runs once per project with no notion of a current document. The derivation therefore lives in `DefaultSiteRenderer.createDocumentVelocityContext`, the one place holding a `DocumentRenderingContext`. The shared `SiteModel` is cloned before the trail is set, so one document's breadcrumbs cannot leak into another's.

**Ancestors only, excluding the matched item.** Skins render the page title after the breadcrumbs, so including the matched item would print the page name twice. On the example above this yields `Apache / Maven / Doxia` with `Introduction` supplied by the skin, reproducing the pre-move trail exactly.

**Href matching is deliberately literal.** It normalises a single leading `/` or `./`, and rejects external links via the existing `SiteUtils.isLink` plus anything carrying `#` or `?`. `DocumentRenderingContext.getOutputPath()` is documented as relative to the site root and the descriptors in this repository are written the same way. Menu hrefs written relative to the current page would not match, and would render as they do today rather than incorrectly.

## Compatibility

With the flag off, `createDocumentVelocityContext` puts the same `SiteModel` instance into the Velocity context as before: no clone, no walk, no computation. An explicit `<breadcrumbs>` element always wins over derivation, so existing sites are unaffected whether or not the flag is set.

## Assumption a reviewer should check

`ref`, `inherit`, and `inheritAsRef` on `<menu>` are assumed to be resolved before the model reaches `SiteRenderingContext`, as `DefaultSiteTool` does when maven-site-plugin invokes the renderer. If that ordering does not hold, an unresolved `ref` menu has no items, derivation finds nothing, and the page renders as it does today — the failure mode is a missing breadcrumb, not a wrong one. This has not been confirmed against an end-to-end site build, which needs the maven-site-plugin side.

The plugin-facing parameter name in apache/maven-site-plugin#1300 is `generateBreadcrumbsFromMenus`, which should be reconciled with the renderer flag name before either ships.

## Tests

`MenuBreadcrumbsTest` covers the derivation algorithm: nested item chains, an explicit trail winning, a page in no menu, external and fragment hrefs, and empty menus. `DeriveBreadcrumbsFromMenuTest` wires the flag through `createDocumentVelocityContext` on a real injected `DefaultSiteRenderer` and asserts the flag-off path leaves the model instance untouched.

Verified: `mvn -o verify` → BUILD SUCCESS, all six modules, `Tests run: 31, Failures: 0, Errors: 0` in doxia-site-renderer and the pre-existing `SiteModelInheritanceAssemblerTest` (25 tests) unchanged.

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).
  The `run-its` profile exists only in `doxia-site-scm-context`, which this change does not touch.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

*This change was created with AI assistance.*
